### PR TITLE
new options: session.cookie persistent and session.check.ssi

### DIFF
--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -140,6 +140,7 @@ local session = {
         httponly = enabled(ngx_var.session_cookie_httponly   or true),
         persistent = enabled(ngx_var.session_cookie_persistent),
     }, check = {
+        ssi    = enabled(ngx_var.session_check_ssi    or true),
         ua     = enabled(ngx_var.session_check_ua     or true),
         scheme = enabled(ngx_var.session_check_scheme or true),
         addr   = enabled(ngx_var.session_check_addr   or false)
@@ -169,7 +170,7 @@ function session.start(opts)
         self.cookie.domain = ngx_var.host
     end
     self.key = concat{
-        ssi                                           or "",
+        self.check.ssi    and ssi                     or "",
         self.check.ua     and ngx_var.http_user_agent or "",
         self.check.addr   and ngx_var.remote_addr     or "",
         self.check.scheme and ngx_var.scheme          or ""


### PR DESCRIPTION
Options to enable persistent sessions.

Usage example:

<pre>
function persistent_session(lifetime)
    session.persistent = true
    session.check.ssi = false --ssi will change after browser closes
    session.check.ua = false  --user could upgrade the browser
    session.cookie.lifetime = lifetime or 2 * 365 * 24 * 3600 --2 years
    return assert(session.start())
end
</pre>
