### PR TITLE
fix save not working after first

### DIFF
--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -97,8 +97,8 @@ function setcookie(session, value, expires)
     local t = type(cookies)
     if t == "table" then
         local found = false
-        for i, cookie in ipairs(cookies) do
-            if cookie:find(needle, 1, true) == 1 then
+        for i, set_cookie in ipairs(cookies) do
+            if set_cookie:find(needle, 1, true) == 1 then
                 cookies[i] = cookie
                 found = true
                 break


### PR DESCRIPTION
save() was not updating the header with the new values, this is because
the variable used to iterate on cookies has the same name as the
variable that contains the new cookie value to be set. renamed iterator
to fix