### PR TITLE
removing unpaired lock

### DIFF
--- a/lib/resty/session/storage/memcache.lua
+++ b/lib/resty/session/storage/memcache.lua
@@ -174,7 +174,6 @@ end
 function memcache:start(i)
     local ok, err = self:connect()
     if ok then
-        ok, err = self:lock(self:key(i))
         self:set_keepalive()
     end
     return ok, err


### PR DESCRIPTION
While test driving them module with memcache storage + locking on, I noticed that requests were hanging; removing the lock statement during start() seemed to help.

Wanted to present it for review (in case I have missed something) ... thx in advance for your feedback.

