### PR TITLE
Avoid  use unix socket and redis password with empty string

### DIFF
--- a/lib/resty/session/storage/memcache.lua
+++ b/lib/resty/session/storage/memcache.lua
@@ -53,7 +53,7 @@ function memcache.new(config)
         }
     }
     local s = c.socket or defaults.socket
-    if s then
+    if s and s ~= "" then
         self.socket = s
     else
         self.host = c.host or defaults.host

--- a/lib/resty/session/storage/redis.lua
+++ b/lib/resty/session/storage/redis.lua
@@ -72,7 +72,7 @@ function redis:connect()
     else
         ok, err = r:connect(self.host, self.port)
     end
-    if ok and self.auth then
+    if ok and self.auth and self.auth ~= "" then
         ok, err = r:get_reused_times()
         if ok == 0 then
             ok, err = r:auth(self.auth)

--- a/lib/resty/session/storage/redis.lua
+++ b/lib/resty/session/storage/redis.lua
@@ -55,7 +55,7 @@ function redis.new(config)
         }
     }
     local s = r.socket or defaults.socket
-    if s and s ~= '' then
+    if s and s ~= "" then
         self.socket = s
     else
         self.host = r.host or defaults.host

--- a/lib/resty/session/storage/redis.lua
+++ b/lib/resty/session/storage/redis.lua
@@ -55,7 +55,7 @@ function redis.new(config)
         }
     }
     local s = r.socket or defaults.socket
-    if s then
+    if s and s ~= '' then
         self.socket = s
     else
         self.host = r.host or defaults.host


### PR DESCRIPTION
When config is  like: 

```
    set $session_storage redis;
    set $session_redis_prefix sessions;
    set $session_redis_socket '';
    set $session_redis_host redis;
    set $session_redis_port 6379;
    set $session_redis_auth '';
```

the redis storage will use unix socket  to connect redis but it doesn't send any exception when try to connect to unix socket `''` or make auth with empty password.