### PR TITLE
Add a configuration for session cookie max size

### DIFF
--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -142,8 +142,8 @@ local function getcookie(session, i)
     local c = var[concat(n)]
     if not c then return nil end
     local l = #c
-    if l <= c.maxsize then return c end
-    return concat{ sub(c, 1, c.maxsize), getcookie(session, i + 1) or "" }
+    if l <= session.cookie.maxsize then return c end
+    return concat{ sub(c, 1, session.cookie.maxsize), getcookie(session, i + 1) or "" }
 end
 
 local function save(session, close)


### PR DESCRIPTION
Hi,
Currently the **data** of each session cookie chunk is limited to 4000 bytes (hardcoded). However the `Set-Cookie` header itself is larger, as it contains more information about the cookie (e.g. expiration date, max age, samesite policy and so on) and that additional information can cause the cookie to exceed 4096 bytes, which is the size limit by Chrome. This in turn will cause the `Set-Cookie` header to be discarded.

This PR introduces a new configuration variable - `session.cookie.maxsize`, defaulting to 4000, which lets one configure the max size of the data portion in each cookie chunk and therefore work around the above issue.