### PR TITLE
fix(open) do not write on opening

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,11 @@
 
 All notable changes to `lua-resty-session` will be documented in this file.
 
+## [3.0] - unreleased
+### Added
+- added idletime setting (#78). This changes the cookie format, and hence is a
+  breaking change.
+
 ## [2.25] - 2019-11-06
 ### Added
 - Add SSL support for the Redis storage option (#75) (thanks @tieske)

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ support for these backends:
 * `shm` aka Lua Shared Dictionary
 * `memcache` aka Memcached Storage Backend (thanks [@zandbelt](https://github.com/zandbelt))
 * `redis` aka Redis Backend
+* `dshm`
 
 Here are some comparisons about the backends:
 
@@ -824,6 +825,15 @@ local uid = session.data.uid
 `session.expires` holds the expiration time of the session (expiration time will be generated when
 `session:save` method is called).
 
+#### number session.usebefore
+
+`session.usebefore` holds the expiration time based on session usgae (expiration time will be generated
+when the session is saved or started). This iexpiry time is only stored client-side in the cookie.
+Note that just opening a session will not update the cookie! To mark the session as used you must call
+`session:start`. (You can also use `session:save` but that will also write session data to the
+storage, whereas just calling `start` reads the session data and updates the `usebefore` value in the
+client-side cookie without writing to the storage, it will just be setting a new cookie)
+
 #### string session.secret
 
 `session.secret` holds the secret that is used in keyed HMAC generation.
@@ -854,6 +864,12 @@ to 3,600 seconds. This can be configured with Nginx `set $session_cookie_lifetim
 set cookie's expiration time on session only (by default) cookies, but it is used if the cookies are
 configured persistent with `session.cookie.persistent == true`. See also notes about
 [ssl_session_timeout](#nginx-configuration-variables).
+
+#### number session.cookie.idletime
+
+`session.cookie.idletime` holds the cookie idletime in seconds in the future. If a cookie is not used
+(idle) for this time, the session becomes invalid. By default this is set to 0 seconds, meaning it is
+disabled. This can be configured with Nginx `set $session_cookie_idletime 300;`.
 
 #### string session.cookie.path
 
@@ -1017,6 +1033,7 @@ set $session_cookie_persistent off;
 set $session_cookie_discard    10;
 set $session_cookie_renew      600;
 set $session_cookie_lifetime   3600;
+set $session_cookie_idletime   0;
 set $session_cookie_path       /;
 set $session_cookie_domain     openresty.org;
 set $session_cookie_samesite   Lax;

--- a/README.md
+++ b/README.md
@@ -828,7 +828,7 @@ local uid = session.data.uid
 #### number session.usebefore
 
 `session.usebefore` holds the expiration time based on session usgae (expiration time will be generated
-when the session is saved or started). This iexpiry time is only stored client-side in the cookie.
+when the session is saved or started). This expiry time is only stored client-side in the cookie.
 Note that just opening a session will not update the cookie! To mark the session as used you must call
 `session:start`. (You can also use `session:save` but that will also write session data to the
 storage, whereas just calling `start` reads the session data and updates the `usebefore` value in the

--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -164,7 +164,8 @@ end
 -- read the cookie for the session object.
 -- @param session_obj (table) the session object for which to read the cookie
 -- @param i (number) do not use! internal recursion variable
--- @return string with cookie data (and the property `session.cookie.chunks` will be set to the actual number of chunks read)
+-- @return string with cookie data (and the property `session.cookie.chunks`
+-- will be set to the actual number of chunks read)
 local function getcookie(session_obj, i)
     local name = session_obj.name
     local n = { "cookie_", name }
@@ -304,13 +305,20 @@ function session.new(opts)
     opts = type(opts) == "table" and opts or defaults
     local cookie_opts, cookie_defaults = opts.cookie or defaults.cookie, defaults.cookie
     local check_opts,  check_defaults = opts.check  or defaults.check,  defaults.check
-    local ident_mod,  ident_name  = prequire("resty.session.identifiers.", opts.identifier or defaults.identifier, "random")
-    local serial_mod, serial_name = prequire("resty.session.serializers.", opts.serializer or defaults.serializer, "json")
-    local enc_mod,    enc_name    = prequire("resty.session.encoders.",    opts.encoder    or defaults.encoder,    "base64")
-    local ciph_mod,   ciph_name   = prequire("resty.session.ciphers.",     opts.cipher     or defaults.cipher,     "aes")
-    local stor_mod,   stor_name   = prequire("resty.session.storage.",     opts.storage    or defaults.storage,    "cookie")
-    local strat_mod,  strat_name  = prequire("resty.session.strategies.",  opts.strategy   or defaults.strategy,   "default")
-    local hmac_mod,   hmac_name   = prequire("resty.session.hmac.",        opts.hmac       or defaults.hmac,       "sha1")
+    local ident_mod,  ident_name  = prequire("resty.session.identifiers.",
+                                    opts.identifier or defaults.identifier, "random")
+    local serial_mod, serial_name = prequire("resty.session.serializers.",
+                                    opts.serializer or defaults.serializer, "json")
+    local enc_mod,    enc_name    = prequire("resty.session.encoders.",
+                                    opts.encoder    or defaults.encoder,    "base64")
+    local ciph_mod,   ciph_name   = prequire("resty.session.ciphers.",
+                                    opts.cipher     or defaults.cipher,     "aes")
+    local stor_mod,   stor_name   = prequire("resty.session.storage.",
+                                    opts.storage    or defaults.storage,    "cookie")
+    local strat_mod,  strat_name  = prequire("resty.session.strategies.",
+                                    opts.strategy   or defaults.strategy,   "default")
+    local hmac_mod,   hmac_name   = prequire("resty.session.hmac.",
+                                    opts.hmac       or defaults.hmac,       "sha1")
     local self = {
         name       = opts.name   or defaults.name,
         identifier = ident_mod,

--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -405,7 +405,6 @@ function session.start(opts)
         return opts, opts.present
     end
     local self, present = session.open(opts)
-    touch(self)
     if present then
         if self.storage.start then
             local ok, err = self.storage:start(self.id)
@@ -416,6 +415,9 @@ function session.start(opts)
            self.expires > now + self.cookie.lifetime then
             local ok, err = save(self)
             if not ok then return nil, err end
+        else
+            -- we're not saving, so we must touch to update idletime/usebefore
+            touch(self)
         end
     else
         local ok, err = save(self)

--- a/lib/resty/session/storage/cookie.lua
+++ b/lib/resty/session/storage/cookie.lua
@@ -58,7 +58,13 @@ end
 -- @param hash (string)
 -- @return encoded cookie-string value
 function cookie:save(id, usebefore, expires, data, hash)
-    return concat({ self.encode(id), tostring(usebefore), tostring(expires), self.encode(data), self.encode(hash) }, self.delimiter)
+    return concat({
+        self.encode(id),
+        tostring(usebefore),
+        tostring(expires),
+        self.encode(data),
+        self.encode(hash)
+    }, self.delimiter)
 end
 
 cookie.touch = cookie.save  -- identical in the 'cookie' case

--- a/lib/resty/session/storage/cookie.lua
+++ b/lib/resty/session/storage/cookie.lua
@@ -18,11 +18,12 @@ end
 -- @param value (string) the string to split in the elements
 -- @return array with the elements in order, or `nil` if the number of elements do not match expectations.
 function cookie:cookie(value)
+    local size = 5
     local result, delim = {}, self.delimiter
     local count, pos = 1, 1
     local match_start, match_end = value:find(delim, 1, true)
     while match_start do
-        if count > 3 then
+        if count == size then
             return nil  -- too many elements
         end
         result[count] = value:sub(pos, match_end - 1)
@@ -30,20 +31,20 @@ function cookie:cookie(value)
         pos = match_end + 1
         match_start, match_end = value:find(delim, pos, true)
     end
-    if count ~= 4 then
-        return nil  -- too little elements (4 expected)
+    if count ~= size then
+        return nil  -- too little elements
     end
-    result[4] = value:sub(pos)
+    result[size] = value:sub(pos)
     return result
 end
 
--- returns 4 decoded data elements from the cookie-string
+-- returns 5 decoded data elements from the cookie-string
 -- @param value (string) the cookie string containing the encoded data.
--- @return id (string), expires(number), data (string), hash (string).
+-- @return id (string), usebefore(number), expires(number), data (string), hash (string).
 function cookie:open(value)
     local r = self:cookie(value)
     if r and r[1] and r[2] and r[3] and r[4] then
-        return self.decode(r[1]), tonumber(r[2]), self.decode(r[3]), self.decode(r[4])
+        return self.decode(r[1]), tonumber(r[2]), tonumber(r[3]), self.decode(r[4]), self.decode(r[5])
     end
     return nil, "invalid"
 end
@@ -51,12 +52,15 @@ end
 -- returns a cookie-string. Note that the cookie-storage does not store anything
 -- server-side in this case.
 -- @param id (string)
--- @param expires(number)
+-- @param usebefore (number)
+-- @param expires (number)
 -- @param data (string)
 -- @param hash (string)
 -- @return encoded cookie-string value
-function cookie:save(id, expires, data, hash)
-    return concat({ self.encode(id), tostring(expires), self.encode(data), self.encode(hash) }, self.delimiter)
+function cookie:save(id, usebefore, expires, data, hash)
+    return concat({ self.encode(id), tostring(usebefore), tostring(expires), self.encode(data), self.encode(hash) }, self.delimiter)
 end
+
+cookie.touch = cookie.save  -- identical in the 'cookie' case
 
 return cookie

--- a/lib/resty/session/storage/dshm.lua
+++ b/lib/resty/session/storage/dshm.lua
@@ -128,14 +128,13 @@ function shm:cookie(value)
     return result
 end
 
-function shm:open(cookie, lifetime)
+function shm:open(cookie)
     local r = self:cookie(cookie)
     if r and r[1] and r[2] and r[3] and r[4] then
         local i, u, e, h = self.decode(r[1]), tonumber(r[2]), tonumber(r[3]), self.decode(r[4])
         local k = self:key(i)
         local d = self:get(concat({self.name , k}, ":"))
         if d then
-            self:touch(concat({self.name , k}, ":"), lifetime)
             d = ngx.decode_base64(d)
         end
 

--- a/lib/resty/session/storage/memcache.lua
+++ b/lib/resty/session/storage/memcache.lua
@@ -154,7 +154,7 @@ function memcache:cookie(value)
     return result
 end
 
-function memcache:open(cookie, lifetime)
+function memcache:open(cookie)
     local c = self:cookie(cookie)
     if c and c[1] and c[2] and c[3] and c[4] then
         local ok, err = self:connect()
@@ -164,9 +164,6 @@ function memcache:open(cookie, lifetime)
             ok, err = self:lock(k)
             if ok then
                 local d = self:get(k)
-                if d then
-                    self:expire(k, floor(lifetime))
-                end
                 self:unlock(k)
                 self:set_keepalive()
                 return i, u, e, d, h

--- a/lib/resty/session/storage/redis.lua
+++ b/lib/resty/session/storage/redis.lua
@@ -173,7 +173,7 @@ function redis:cookie(value)
     return result
 end
 
-function redis:open(cookie, lifetime)
+function redis:open(cookie)
     local c = self:cookie(cookie)
     if c and c[1] and c[2] and c[3] and c[4] then
         local ok, err = self:connect()
@@ -183,9 +183,6 @@ function redis:open(cookie, lifetime)
             ok, err = self:lock(k)
             if ok then
                 local d = self:get(k)
-                if d then
-                    self:expire(k, floor(lifetime))
-                end
                 self:unlock(k)
                 self:set_keepalive()
                 return i, u, e, d, h

--- a/lib/resty/session/storage/redis.lua
+++ b/lib/resty/session/storage/redis.lua
@@ -149,30 +149,36 @@ function redis:delete(k)
     self.redis:del(k)
 end
 
-function redis:cookie(c)
-    local r, d = {}, self.delimiter
-    local i, p, s, e = 1, 1, c:find(d, 1, true)
-    while s do
-        if i > 2 then
-            return nil
+-- Extracts the elements from the cookie-string (string-split essentially).
+-- @param value (string) the string to split in the elements
+-- @return array with the elements in order, or `nil` if the number of elements do not match expectations.
+function redis:cookie(value)
+    local size = 4
+    local result, delim = {}, self.delimiter
+    local count, pos = 1, 1
+    local match_start, match_end = value:find(delim, 1, true)
+    while match_start do
+        if count == size then
+            return nil  -- too many elements
         end
-        r[i] = c:sub(p, e - 1)
-        i, p = i + 1, e + 1
-        s, e = c:find(d, p, true)
+        result[count] = value:sub(pos, match_end - 1)
+        count = count + 1
+        pos = match_end + 1
+        match_start, match_end = value:find(delim, pos, true)
     end
-    if i ~= 3 then
-        return nil
+    if count ~= size then
+        return nil  -- too little elements
     end
-    r[3] = c:sub(p)
-    return r
+    result[size] = value:sub(pos)
+    return result
 end
 
 function redis:open(cookie, lifetime)
     local c = self:cookie(cookie)
-    if c and c[1] and c[2] and c[3] then
+    if c and c[1] and c[2] and c[3] and c[4] then
         local ok, err = self:connect()
         if ok then
-            local i, e, h = self.decode(c[1]), tonumber(c[2]), self.decode(c[3])
+            local i, u, e, h = self.decode(c[1]), tonumber(c[2]), tonumber(c[3]), self.decode(c[4])
             local k = self:key(i)
             ok, err = self:lock(k)
             if ok then
@@ -182,7 +188,7 @@ function redis:open(cookie, lifetime)
                 end
                 self:unlock(k)
                 self:set_keepalive()
-                return i, e, d, h
+                return i, u, e, d, h
             end
             self:set_keepalive()
             return nil, err
@@ -202,7 +208,25 @@ function redis:start(i)
     return ok, err
 end
 
-function redis:save(i, e, d, h, close)
+-- Generates the cookie value.
+-- Similar to 'save', but without writing to the storage.
+-- @param id (string)
+-- @param usebefore (number)
+-- @param expires(number) lifetime (ttl) is calculated from this
+-- @param data (string)
+-- @param hash (string)
+-- @return encoded cookie-string value, or nil+err
+function redis:touch(id, usebefore, expires, data, hash, close)
+    local lifetime = floor(expires - now())
+
+    if lifetime <= 0 then
+        return nil, "expired"
+    end
+
+    return concat({ self.encode(id), usebefore, expires, self.encode(hash) }, self.delimiter)
+end
+
+function redis:save(i, u, e, d, h, close)
     local ok, err = self:connect()
     if ok then
         local l, k = floor(e - now()), self:key(i)
@@ -213,7 +237,7 @@ function redis:save(i, e, d, h, close)
             end
             self:set_keepalive()
             if ok then
-                return concat({ self.encode(i), e, self.encode(h) }, self.delimiter)
+                return concat({ self.encode(i), u, e, self.encode(h) }, self.delimiter)
             end
             return ok, err
         end

--- a/lib/resty/session/storage/shm.lua
+++ b/lib/resty/session/storage/shm.lua
@@ -85,9 +85,8 @@ end
 
 -- Opens session and writes it to the store. Returns 4 decoded data elements from the cookie-string.
 -- @param value (string) the cookie string containing the encoded data.
--- @param lifetime (number) lifetime in seconds of the data in the store (ttl)
 -- @return id (string), expires(number), data (string), hash (string).
-function shm:open(value, lifetime)
+function shm:open(value)
     local r = self:cookie(value)
     if r and r[1] and r[2] and r[3] and r[4] then
         local id, usebefore, expires, hash = self.decode(r[1]), tonumber(r[2]), tonumber(r[3]), self.decode(r[4])
@@ -98,7 +97,6 @@ function shm:open(value, lifetime)
             if ok then
                 local cshm = self.store
                 local data = cshm:get(key)
-                cshm:set(key, data, lifetime)
                 l:unlock()
                 return id, usebefore, expires, data, hash
             end
@@ -106,7 +104,6 @@ function shm:open(value, lifetime)
         else
             local cshm = self.store
             local data = cshm:get(key)
-            cshm:set(key, data, lifetime)
             return id, usebefore, expires, data, hash
         end
     end

--- a/lib/resty/session/strategies/default.lua
+++ b/lib/resty/session/strategies/default.lua
@@ -6,10 +6,14 @@ local default = {}
 
 
 local function update(handler, session_obj, close)
-  local id, usebefore, expires, storage = session_obj.id, session_obj.usebefore, session_obj.expires, session_obj.storage
+  local id = session_obj.id
+  local usebefore = session_obj.usebefore
+  local expires = session_obj.expires
+  local storage = session_obj.storage
   local key = session_obj.hmac(session_obj.secret, id .. expires)
   local data = session_obj.serializer.serialize(session_obj.data)
-  local hash = session_obj.hmac(key, concat{ id, usebefore, expires, data, session_obj.key })
+  local hash = session_obj.hmac(key,
+               concat{ id, usebefore, expires, data, session_obj.key })
 
   data = session_obj.cipher:encrypt(data, key, id, session_obj.key)
   return handler(storage, id, usebefore, expires, data, hash, close)
@@ -35,7 +39,8 @@ end
 -- Validates the expiry-time and hash.
 -- @param session_obj (table) the session object to store the data in
 -- @param cookie (string) the cookie string to open
--- @return `true` if ok, and will have set session properties; id, expires, data and present. Returns `nil` otherwise.
+-- @return `true` if ok, and will have set session properties; id, expires, data
+-- and present. Returns `nil` otherwise.
 function default.open(session_obj, cookie)
   local id, usebefore, expires, data, hash = session_obj.storage:open(cookie, session_obj.cookie.lifetime)
   local now = time()

--- a/lib/resty/session/strategies/default.lua
+++ b/lib/resty/session/strategies/default.lua
@@ -42,7 +42,7 @@ end
 -- @return `true` if ok, and will have set session properties; id, expires, data
 -- and present. Returns `nil` otherwise.
 function default.open(session_obj, cookie)
-  local id, usebefore, expires, data, hash = session_obj.storage:open(cookie, session_obj.cookie.lifetime)
+  local id, usebefore, expires, data, hash = session_obj.storage:open(cookie)
   local now = time()
   if id and
      expires and expires > now and

--- a/lib/resty/session/strategies/default.lua
+++ b/lib/resty/session/strategies/default.lua
@@ -4,17 +4,31 @@ local concat = table.concat
 
 local default = {}
 
+
+local function update(handler, session_obj, close)
+  local id, usebefore, expires, storage = session_obj.id, session_obj.usebefore, session_obj.expires, session_obj.storage
+  local key = session_obj.hmac(session_obj.secret, id .. expires)
+  local data = session_obj.serializer.serialize(session_obj.data)
+  local hash = session_obj.hmac(key, concat{ id, usebefore, expires, data, session_obj.key })
+
+  data = session_obj.cipher:encrypt(data, key, id, session_obj.key)
+  return handler(storage, id, usebefore, expires, data, hash, close)
+end
+
 -- save the session data to the underlying storage adapter.
 -- @param session_obj (table) the session object to store
 -- @return result from `storage.save`.
 function default.save(session_obj, close)
-  local id, expires, storage = session_obj.id, session_obj.expires, session_obj.storage
-  local key = session_obj.hmac(session_obj.secret, id .. expires)
-  local data = session_obj.serializer.serialize(session_obj.data)
-  local hash = session_obj.hmac(key, concat{ id, expires, data, session_obj.key })
+  return update(session_obj.storage.save, session_obj, close)
+end
 
-  data = session_obj.cipher:encrypt(data, key, id, session_obj.key)
-  return storage:save(id, expires, data, hash, close)
+-- Generates a new cookie, without writing to the store.
+-- Used when 'idletime' is used and 'usebefore' is altered without the content being
+-- changed.
+-- @param session_obj (table) the session object to store
+-- @return result from `storage.save`.
+function default.touch(session_obj, close)
+  return update(session_obj.storage.touch, session_obj, close)
 end
 
 -- Calls into the underlying storage adapter to load the cookie.
@@ -23,13 +37,18 @@ end
 -- @param cookie (string) the cookie string to open
 -- @return `true` if ok, and will have set session properties; id, expires, data and present. Returns `nil` otherwise.
 function default.open(session_obj, cookie)
-  local id, expires, data, hash = session_obj.storage:open(cookie, session_obj.cookie.lifetime)
-  if id and expires and expires > time() and data and hash then
+  local id, usebefore, expires, data, hash = session_obj.storage:open(cookie, session_obj.cookie.lifetime)
+  local now = time()
+  if id and
+     expires and expires > now and
+     usebefore and usebefore > now and
+     data and hash then
     local key = session_obj.hmac(session_obj.secret, id .. expires)
     data = session_obj.cipher:decrypt(data, key, id, session_obj.key)
-    if data and session_obj.hmac(key, concat{ id, expires, data, session_obj.key }) == hash then
+    if data and session_obj.hmac(key, concat{ id, usebefore, expires, data, session_obj.key }) == hash then
       data = session_obj.serializer.deserialize(data)
       session_obj.id = id
+      session_obj.usebefore = usebefore
       session_obj.expires = expires
       session_obj.data = type(data) == "table" and data or {}
       session_obj.present = true

--- a/lib/resty/session/strategies/regenerate.lua
+++ b/lib/resty/session/strategies/regenerate.lua
@@ -55,7 +55,7 @@ end
 -- @return `true` if ok, and will have set session properties; id, usebefore,
 -- expires, data and present. Returns `nil` otherwise.
 function regenerate.open(session_obj, cookie)
-  local id, usebefore, expires, data, hash = session_obj.storage:open(cookie, session_obj.cookie.lifetime)
+  local id, usebefore, expires, data, hash = session_obj.storage:open(cookie)
   local now = time()
   if id and
      expires and expires > now and

--- a/lib/resty/session/strategies/regenerate.lua
+++ b/lib/resty/session/strategies/regenerate.lua
@@ -8,7 +8,11 @@ local regenerate = {}
 -- @param session_obj (table) the session object to store
 -- @return result from `storage.save`.
 function regenerate.save(session_obj, close)
-  local id, usebefore, expires, storage = session_obj.id, session_obj.usebefore, session_obj.expires, session_obj.storage
+  local id = session_obj.id
+  local usebefore = session_obj.usebefore
+  local expires = session_obj.expires
+  local storage = session_obj.storage
+
   if storage.ttl then
     -- if there is a ttl, then we set the lifetime to the 'discard' value as a
     -- grace period
@@ -31,7 +35,11 @@ end
 -- @param session_obj (table) the session object to store
 -- @return result from `storage.save`.
 function regenerate.touch(session_obj, close)
-  local id, usebefore, expires, storage = session_obj.id, session_obj.usebefore, session_obj.expires, session_obj.storage
+  local id = session_obj.id
+  local usebefore = session_obj.usebefore
+  local expires = session_obj.expires
+  local storage = session_obj.storage
+
   local key = session_obj.hmac(session_obj.secret, id)
   local data = session_obj.serializer.serialize(session_obj.data)
   local hash = session_obj.hmac(key, concat{ id, usebefore, data, session_obj.key })
@@ -44,7 +52,8 @@ end
 -- Validates the expiry-time and hash.
 -- @param session_obj (table) the session object to store the data in
 -- @param cookie (string) the cookie string to open
--- @return `true` if ok, and will have set session properties; id, usebefore, expires, data and present. Returns `nil` otherwise.
+-- @return `true` if ok, and will have set session properties; id, usebefore,
+-- expires, data and present. Returns `nil` otherwise.
 function regenerate.open(session_obj, cookie)
   local id, usebefore, expires, data, hash = session_obj.storage:open(cookie, session_obj.cookie.lifetime)
   local now = time()


### PR DESCRIPTION
the `open` method has the promise to not touch the session. So it should also not update the `ttl` in the datastore.

Most likely this will also be a performance improvement, since we're skipping a write operation when opening a session.

This is build on top of #78 so only the last commit is relevant here.