### PR TITLE
make Cookie support SameSite=None

### DIFF
--- a/README.md
+++ b/README.md
@@ -870,8 +870,8 @@ For `localhost` this is omitted.
 #### string session.cookie.samesite
 
 `session.cookie.samesite` holds the value of the cookie SameSite flag. By default we do use value of `Lax`.
-The possible values are `Lax`, `Strict`, and `off`. Actually, setting this parameter anything else than
-`Lax` or `Strict` will turn this off (but in general, you shouldn't do it). If you want better protection
+The possible values are `Lax`, `Strict`, `None`, and `off`. Actually, setting this parameter anything else than
+`Lax`, `Strict` or `None` will turn this off (but in general, you shouldn't do it). If you want better protection
 against Cross Site Request Forgery (CSRF), set this to `Strict`. Default value of `Lax` gives you quite a
 good protection against CSRF, but `Strict` goes even further.
 

--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -83,7 +83,7 @@ local function setcookie(session_obj, value, expires)
     k[i]   = "; Path="
     k[i+1] = cookie_obj.path or "/"
     i=i+2
-    if cookie_samesite == "Lax" or cookie_samesite == "Strict" then
+    if cookie_samesite == "Lax" or cookie_samesite == "Strict" or cookie_samesite == "None" then
         k[i] = "; SameSite="
         k[i+1] = cookie_samesite
         i=i+2


### PR DESCRIPTION
`SameSite=off` creates cookies without any `SameSite` attribute at all, which recent versions of Chrome and Firefox treat (or will treat soon) the same as `SameSite=Lax`. For some use-cases you really want to send Cookies on cross domain request and now have to set `SameSite` to `None`.

This trivial PR adds `None` to the supported values for `SameSite`. 