### PR TITLE
the ttl function tries to use a closed redis socket

### DIFF
--- a/lib/resty/session/storage/redis.lua
+++ b/lib/resty/session/storage/redis.lua
@@ -249,7 +249,13 @@ end
 
 function redis:ttl(i, ttl)
   local k = self:key(i)
-  return self:expire(k, floor(ttl))
+  local ok, err = self:connect()
+  if ok then
+    local res, err = self:expire(k, floor(ttl))
+    self:set_keepalive()
+    return res, err
+  end
+  retunr nil, err
 end
 
 


### PR DESCRIPTION
We are using the regenerate strategy and have been seeing

```
[error] 15#15: *2867 attempt to send data on a closed socket: u:00007FEAD1172CE8, c:0000000000000000, ft:0 eof:0, client: 10.244.3.56, server: ,"
```

in our logs. I've traced this down to `redis:ttl` calling `expire` without opening the connection first.
 

