### PR TITLE
save function can leak redis connection

### DIFF
--- a/lib/resty/session/storage/redis.lua
+++ b/lib/resty/session/storage/redis.lua
@@ -219,8 +219,8 @@ function redis:save(i, e, d, h, close)
         end
         if close then
             self:unlock(k)
-            self:set_keepalive()
         end
+        self:set_keepalive()
         return nil, "expired"
     end
     return ok, err


### PR DESCRIPTION
While chasing #85 I looked for paths where a redis connection might leak and found that under rare circumstances `save(false)` would skip `set_keepalive`.