### PR TITLE
make locking in redis work

### DIFF
--- a/lib/resty/session/storage/redis.lua
+++ b/lib/resty/session/storage/redis.lua
@@ -117,7 +117,7 @@ function redis:lock(k)
     local l = concat({ k, "lock" }, "." )
     for _ = 1, i do
         local ok = r:setnx(l, "1")
-        if ok then
+        if ok == 1 then
             return r:expire(l, m + 1)
         end
         sleep(w)


### PR DESCRIPTION
setnx return the (truthy) value 0 if the key already exists, so the
existing code would always believe to own the lock even if it didn't

see https://redis.io/commands/setnx

Signed-off-by: Stefan Bodewig <stefan.bodewig@innoq.com>