### PR TITLE
fix typo introduced with #85

### DIFF
--- a/lib/resty/session/storage/redis.lua
+++ b/lib/resty/session/storage/redis.lua
@@ -255,7 +255,7 @@ function redis:ttl(i, ttl)
     self:set_keepalive()
     return res, err
   end
-  retunr nil, err
+  return nil, err
 end
 
 


### PR DESCRIPTION
Sorry, I broke the `ttl` function with #85 - even github syntax highlighting would have told me.

This is what you get for copying code change between two different repos as I did. I'll try to do better next time :-)