### PR TITLE
unlock old session id when regenerating the session

### DIFF
--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -203,13 +203,18 @@ end
 -- @param flush (boolean) if thruthy the old session will be destroyed, and data deleted
 -- @return nothing
 local function regenerate(session, flush)
-    local old_id = session.present and session.id
+    local old_id, destroyed = session.present and session.id, false
     session.id = session:identifier()
     if flush then
         if old_id and session.storage.destroy then
             session.storage:destroy(old_id)
+            destroyed = true
         end
         session.data = {}
+    end
+    if not destroyed and session.storage.close then
+        -- unlock old session id
+        session.storage:close(old_id)
     end
 end
 

--- a/lib/resty/session/strategies/regenerate.lua
+++ b/lib/resty/session/strategies/regenerate.lua
@@ -14,6 +14,10 @@ function regenerate.save(session_obj, close)
     -- grace period
     storage:ttl(id, session_obj.cookie.discard)
   end
+  if storage.close then
+      -- unlock old session id
+      storage:close(id)
+  end
 
   -- recreate a new ID, since the old one has a temporary discard-ttl
   id = session_obj:identifier()


### PR DESCRIPTION
Right now there is no way to unlock the "old" session id when the session gets associated with a new id and concurrent requests are blocked until `maxwait` expires.