### PR TITLE
fix(session) session:hide() issue

### DIFF
--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -15,6 +15,7 @@ local max          = math.max
 local find         = string.find
 local gsub         = string.gsub
 local sub          = string.sub
+local match        = string.match
 local type         = type
 local pcall        = pcall
 local tonumber     = tonumber
@@ -648,6 +649,10 @@ function session:close()
     return true
 end
 
+local function ltrim(s)
+    return match(s,'^%s*(.*%S)')
+end
+
 function session:hide()
     local cookies = var.http_cookie
     if not cookies then
@@ -671,7 +676,7 @@ function session:hide()
                 or tonumber(sub(cookie_name, name_len + 2), 10) == nil
                 then
                     j = j + 1
-                    results[j] = cookie
+                    results[j] = ltrim(cookie)
                 end
             end
         end
@@ -690,7 +695,7 @@ function session:hide()
                 or tonumber(sub(cookie_name, name_len + 2), 10) == nil
                 then
                     j = j + 1
-                    results[j] = cookie
+                    results[j] = ltrim(cookie)
                 end
             end
         end


### PR DESCRIPTION
Because of space in the beginning of Cookie header session:hide()
invalidates all cookies.

My pseudocode to test:

```Lua
    print(ngx.var.cookie_name1) -- print [123]
    print(ngx.var.cookie_name2) -- print [321]
    print(ngx.var.http_cookie)  -- print [name1=123; name2=321]

    hide("name1")

    print(ngx.var.cookie_name1) -- print [nil]
    print(ngx.var.cookie_name2) -- print [nil]
    print(ngx.var.http_cookie)  -- print [ name2=321] notice a space in the beginning
```
