### PR TITLE
Do not send cookie header as multiple headers on session:hide

### DIFF
--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -743,7 +743,7 @@ function session:hide()
     if j == 0 then
         clear_header("Cookie")
     else
-        set_header("Cookie", results)
+        set_header("Cookie", concat(results, "; ", 1, j))
     end
 end
 


### PR DESCRIPTION
RFC 2616 (https://tools.ietf.org/html/rfc2616#page-32) states that multiple headers with the same name are allowed if the actual data being sent within that header is a `comma-separated list`. 
```
   Multiple message-header fields with the same field-name MAY be
   present in a message if and only if the entire field-value for that
   header field is defined as a comma-separated list [i.e., #(values)].
   It MUST be possible to combine the multiple header fields into one
   "field-name: field-value" pair, without changing the semantics of the
   message, by appending each subsequent field-value to the first, each
   separated by a comma. The order in which header fields with the same
   field-name are received is therefore significant to the
   interpretation of the combined field value, and thus a proxy MUST NOT
   change the order of these field values when a message is forwarded.
```
So if the following headers are sent:
```
Foo: bar
Foo: baz
```
Then the server should interpret the headers as:
```
Foo: bar,baz
```

It appears that in version 3.5 of this package, `set_header("Cookie", concat(results, "; ", 1, j))` was changed to `set_header("Cookie", results)`. Which according to the https://github.com/openresty/lua-nginx-module#ngxreqset_header means that the `session:hide()` function will convert an inbound Cookie header from:
```
Cookie: foo=bar; baz=qux
```
Into
```
Cookie: foo=bar
Cookie: baz=qux
```
Which the server will interpret as:
```
Cookie: foo=bar,baz=qux
```
This conflicts with the definition of the cookie header which requires that cookies be separated by semicolons: https://tools.ietf.org/html/rfc6265 (mozilla example here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies)

This PR reverts this line back to the previous version, since that will preserve the cookie header so that it appears as the backend server expects it to, e.g.:
```
Cookie: luasessioncookie=mysessioncookie; cookie1=scrumptious; cookie2=delicious
```
will be sent to the backend on session hide as
```
Cookie: cookie1=scrumptious; cookie2=delicious
```
and *not* as:
```
Cookie: cookie1=scrumptious, cookie2=delicious
```