### PR TITLE
chore(*) release 3.6

### DIFF
--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -373,7 +373,7 @@ local function init()
 end
 
 local session = {
-    _VERSION = "3.5"
+    _VERSION = "3.6"
 }
 
 session.__index = session


### PR DESCRIPTION
### Summary

`session:hide` to only set a single cookie header (at max), for a better HTTP 1.x compatibility.