### PR TITLE
chore(*) release 3.8

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,11 @@
 
 All notable changes to `lua-resty-session` will be documented in this file.
 
+## [3.8] - 2021-01-04
+### Added
+- Connection options are now passed to `redis cluster client` as well.
+
+
 ## [3.7] - 2020-10-27
 ### Fixed
 - Fix #107 where `session.start` could release a lock for a short period

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014 – 2020, Aapo Talvensaari
+Copyright (c) 2014 – 2021, Aapo Talvensaari
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -1171,7 +1171,7 @@ The changes of every release of this module is recorded in [Changes.md](https://
 `lua-resty-session` uses two clause BSD license.
 
 ```
-Copyright (c) 2014 – 2020 Aapo Talvensaari
+Copyright (c) 2014 – 2021 Aapo Talvensaari
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -374,7 +374,7 @@ local function init()
 end
 
 local session = {
-    _VERSION = "3.7"
+    _VERSION = "3.8"
 }
 
 session.__index = session


### PR DESCRIPTION
### Summary

- Connection options are now passed to `redis cluster client` as well.