### PR TITLE
fear(aes) add aes gcm-mode support

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,9 @@ All notable changes to `lua-resty-session` will be documented in this file.
 
 ## Unreleased
 ### Added
+- AES GCM mode support was added to AES cipher.
+  This is recommended, but for backward compatibility it was not set as default.
+  It will be changed in 4.0 release.
 - Redis ACL authentication is now available.
   - Add `session_redis_username`
   - Add `session_redis_password`

--- a/README.md
+++ b/README.md
@@ -544,9 +544,9 @@ By default this will use `256` bits key size. This can be configured with Nginx
 **mode**
 
 `session.aes.mode` holds the mode of the cipher. `lua-resty-string` supports AES in `ecb`, `cbc`,
-`cfb1`, `cfb8`, `cfb128`, `ofb`, and `ctr` modes (ctr mode is not available with 256 bit keys).
-See `aes.cipher` function in `lua-resty-string` for more information. By default `cbc` mode is
-used. This can be configured with Nginx `set $session_aes_mode cbc;`.
+`cfb1`, `cfb8`, `cfb128`, `ofb`, `ctr`, and `gcm` (recommended!) modes (ctr mode is not available
+with 256 bit keys).  See `aes.cipher` function in `lua-resty-string` for more information.
+By default `cbc` mode is  used. This can be configured with Nginx `set $session_aes_mode cbc;`.
 
 **hash**
 
@@ -580,10 +580,11 @@ There isn't any settings for None adapter as it is basically a no-op adapter.
 If you want to write your own cipher adapter, you need to implement these three methods:
 
 * `cipher new(session)`
-* `string cipher:encrypt(data, key, iv or salt, associated data)`
-* `string cipher:decrypt(ciphertext, key, iv or salt, associated data)`
+* `string, err, tag = cipher:encrypt(data, key, salt, aad)`
+* `string, err, tag = cipher:decrypt(data, key, salt, aad, tag)`
 
-If you do not use say iv or associated data in your cipher, you can ignore them.
+If you do not use say salt or aad (associated data) in your cipher, you can ignore them.
+If you don't use `AEAD` construct (like `AES in GCM-mode`), don't return `tag`.
 
 You have to place your adapter inside `resty.session.ciphers` for auto-loader to work.
 

--- a/lib/resty/session/ciphers/none.lua
+++ b/lib/resty/session/ciphers/none.lua
@@ -4,11 +4,11 @@ function cipher.new()
     return cipher
 end
 
-function cipher.encrypt(_, data)
+function cipher.encrypt(_, data, _, _)
     return data
 end
 
-function cipher.decrypt(_, data)
+function cipher.decrypt(_, data, _, _, _)
     return data
 end
 

--- a/lib/resty/session/strategies/default.lua
+++ b/lib/resty/session/strategies/default.lua
@@ -8,9 +8,9 @@ function strategy.load(session, cookie, key, keep_lock)
   local id         = cookie.id
   local id_encoded = session.encoder.encode(id)
 
-  local data, err
+  local data, err, tag
   if storage.open then
-    data, err = session.storage:open(id_encoded, keep_lock)
+    data, err = storage:open(id_encoded, keep_lock)
     if not data then
       return nil, err or "cookie data was not found"
     end
@@ -29,27 +29,50 @@ function strategy.load(session, cookie, key, keep_lock)
 
   local hkey = session.hmac(session.secret, key)
 
-  data, err = session.cipher:decrypt(data, hkey, id, session.key)
+  data, err, tag = session.cipher:decrypt(data, hkey, id, session.key, hash)
   if not data then
-    session.storage:close(id_encoded)
+    if storage.close then
+      storage:close(id_encoded)
+    end
+
     return nil, err or "unable to decrypt data"
   end
 
-  local input = concat{ key, data, session.key }
-  if session.hmac(hkey, input) ~= hash then
-    session.storage:close(id_encoded)
-    return nil, "cookie has invalid signature"
+  if tag then
+    if tag ~= hash then
+      if storage.close then
+        storage:close(id_encoded)
+      end
+
+      return nil, "cookie has invalid tag"
+    end
+
+  else
+    local input = concat{ key, data, session.key }
+    if session.hmac(hkey, input) ~= hash then
+      if storage.close then
+        storage:close(id_encoded)
+      end
+
+      return nil, "cookie has invalid signature"
+    end
   end
 
   data, err = session.compressor:decompress(data)
   if not data then
-    session.storage:close(id_encoded)
+    if storage.close then
+      storage:close(id_encoded)
+    end
+
     return nil, err or "unable to decompress data"
   end
 
   data, err = session.serializer.deserialize(data)
   if not data then
-    session.storage:close(id_encoded)
+    if storage.close then
+      storage:close(id_encoded)
+    end
+
     return nil, err or "unable to deserialize data"
   end
 
@@ -102,7 +125,6 @@ function strategy.modify(session, action, close, key)
     key = concat{ id, expires, usebefore }
   end
 
-  local hkey = session.hmac(session.secret, key)
   local data, err = session.serializer.serialize(session.data)
   if not data then
     if close and storage.close then
@@ -121,10 +143,11 @@ function strategy.modify(session, action, close, key)
     return nil, err or "unable to compress data"
   end
 
-  local hash = session.hmac(hkey, concat{ key, data, session.key })
+  local hkey = session.hmac(session.secret, key)
 
-  data, err = session.cipher:encrypt(data, hkey, id, session.key)
-  if not data then
+  local encrypted_data, tag
+  encrypted_data, err, tag = session.cipher:encrypt(data, hkey, id, session.key)
+  if not encrypted_data then
     if close and storage.close then
       storage:close(id_encoded)
     end
@@ -132,9 +155,18 @@ function strategy.modify(session, action, close, key)
     return nil, err
   end
 
+  local hash
+  if tag then
+    hash = tag
+  else
+    -- it would be better to calculate signature from encrypted_data,
+    -- but this is kept for backward compatibility
+    hash = session.hmac(hkey, concat{ key, data, session.key })
+  end
+
   if action == "save" and storage.save then
     local ok
-    ok, err = storage:save(id_encoded, ttl, data, close)
+    ok, err = storage:save(id_encoded, ttl, encrypted_data, close)
     if not ok then
       return nil, err
     end
@@ -156,8 +188,8 @@ function strategy.modify(session, action, close, key)
   if storage.save then
     cookie = concat({ id_encoded, expires, hash }, "|")
   else
-    data = session.encoder.encode(data)
-    cookie = concat({ id_encoded, expires, data, hash }, "|")
+    local encoded_data = session.encoder.encode(encrypted_data)
+    cookie = concat({ id_encoded, expires, encoded_data, hash }, "|")
   end
 
   return cookie
@@ -187,9 +219,11 @@ end
 
 function strategy.close(session)
   local id = session.id
-  local storage = session.storage
-  if id and storage.close then
-    return storage:close(session.encoder.encode(id))
+  if id then
+    local storage = session.storage
+    if storage.close then
+      return storage:close(session.encoder.encode(id))
+    end
   end
 
   return true

--- a/lib/resty/session/strategies/regenerate.lua
+++ b/lib/resty/session/strategies/regenerate.lua
@@ -25,8 +25,8 @@ function strategy.touch(session, close)
 end
 
 function strategy.save(session, close)
-  local storage = session.storage
   if session.present then
+    local storage = session.storage
     if storage.ttl then
       storage:ttl(session.encoder.encode(session.id), session.cookie.discard, true)
     elseif storage.close then


### PR DESCRIPTION
Adds AES-GCM mode support in AES cipher. This is an AEAD construct
that is preferred over the default CBC mode that is a subject
to padding oracle. The AES-GCM will be the default on `4.0` when
that is released, but right now the default is not changed for backward
compatibility reasons.