### PR TITLE
fix(regenerate) flush argument and missing session id

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,12 @@
 
 All notable changes to `lua-resty-session` will be documented in this file.
 
+## [3.10] - 2022-01-14
+### Fixed
+- 3.9 introduced an issue where calling session:regenerate with flush=true,
+  didn't really flush if the session strategy was `regenerate`.
+
+
 ## [3.9] - 2022-01-14
 ### Fixed
 - Fix #138 issue of chunked cookies are not expired when session shrinks,

--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -684,9 +684,18 @@ end
 
 function session:regenerate(flush, close)
     close = close ~= false
-    if not self.strategy.regenerate then
+    if self.strategy.regenerate then
+        if flush then
+            self.data = {}
+        end
+
+        if not self.id then
+            self.id = session:identifier()
+        end
+    else
         regenerate(self, flush)
     end
+
     return save(self, close)
 end
 


### PR DESCRIPTION
### Summary

3.9 release introduces a small bug where the session:regenerate flush parameter was not taken in account. I also added automatic id generation just in case it is missing for some reason.