### PR TITLE
fix(session): remember_meta false check

### DIFF
--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -1269,7 +1269,10 @@ local function clear_request_cookie(self, remember)
   if self.storage then
     cookie_chunks = 1
   else
-    local data_size = remember and self.remember_meta.data_size or self.meta.data_size
+    local data_size = remember                     and
+                      self.remember_meta           and
+                      self.remember_meta.data_size or
+                      self.meta.data_size
     cookie_chunks = calculate_cookie_chunks(cookie_name_size, data_size) or 1
   end
 
@@ -2191,7 +2194,7 @@ end
 
 
 local session = {
-  _VERSION = "4.0.0",
+  _VERSION = "4.0.1",
   metatable = metatable,
 }
 

--- a/lua-resty-session-4.0.1-1.rockspec
+++ b/lua-resty-session-4.0.1-1.rockspec
@@ -1,8 +1,8 @@
 package = "lua-resty-session"
-version = "4.0.0-1"
+version = "4.0.1-1"
 source = {
   url = "git+https://github.com/bungle/lua-resty-session.git",
-  tag = "v4.0.0",
+  tag = "v4.0.1",
 }
 description = {
   summary = "Session Library for OpenResty - Flexible and Secure",


### PR DESCRIPTION
The default value for `self.remember_meta` is `false` but the parameter is then treated as a table.
This was causing a problem (during calculation of cookie chunks) when the session was opened with `cookie` storage and `remember=true` where the boolean value was being indexed.