### PR TITLE
fix(utils): disables the SP800-132 compliance checks on FIPS-mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ http {
       storage  = "cookie",
     })
   }
-  
+
   server {
     listen       8080;
     server_name  localhost;
@@ -64,7 +64,7 @@ http {
         session:set_subject("OpenResty Fan")
         session:set("quote", "The quick brown fox jumps over the lazy dog")
         local ok, err = session:save()
-       
+
         ngx.say(string.format([[
           <html>
           <body>
@@ -79,7 +79,7 @@ http {
     location /started {
       content_by_lua_block {
         local session, err = require "resty.session".start()
-        
+
         ngx.say(string.format([[
           <html>
           <body>
@@ -95,14 +95,14 @@ http {
         ))
       }
     }
-    
+
     location /modify {
       content_by_lua_block {
         local session, err = require "resty.session".start()
         session:set_subject("Lua Fan")
         session:set("quote", "Lorem ipsum dolor sit amet")
         local _, err_save = session:save()
-        
+
         ngx.say(string.format([[
           <html>
           <body>
@@ -113,7 +113,7 @@ http {
         ]], err or err_save or "no error"))
       }
     }
-    
+
     location /modified {
       content_by_lua_block {
         local session, err = require "resty.session".start()
@@ -133,7 +133,7 @@ http {
         ))
       }
     }
-    
+
     location /destroy {
       content_by_lua_block {
         local ok, err = require "resty.session".destroy()
@@ -148,7 +148,7 @@ http {
         ]], err or "no error"))
       }
     }
-    
+
     location /destroyed {
       content_by_lua_block {
         local session, err = require "resty.session".open()
@@ -165,9 +165,9 @@ http {
           err or "no error"
         ))
       }
-    }    
+    }
   }
-}  
+}
 ```
 
 
@@ -823,7 +823,7 @@ local session = require "resty.session".new()
 local ok, err = session:open()
 if ok then
   -- session exists
-  
+
 else
   -- session did not exists or was invalid
 end
@@ -1242,7 +1242,7 @@ and
 
 ```
 [ PAYLOAD --]
-[ Data  *B  ]   
+[ Data  *B  ]
 ```
 
 Both the `HEADER` and `PAYLOAD` are base64 url-encoded before putting in a `Set-Cookie` header.
@@ -1257,7 +1257,7 @@ Header fields explained:
 - Flags: binary packed flags (short) in a two byte little endian form.
 - SID: `32` bytes of crypto random data (Session ID).
 - Created at: binary packed secs from epoch in a little endian form, truncated to 5 bytes.
-- Rolling Offset: binary packed secs from creation time in a little endian form (integer). 
+- Rolling Offset: binary packed secs from creation time in a little endian form (integer).
 - Size: binary packed data size in a three byte little endian form.
 - Tag: `16` bytes of authentication tag from AES-256-GCM encryption of the data.
 - Idling Offset: binary packed secs from creation time + rolling offset in a little endian form, truncated to 3 bytes.
@@ -1269,7 +1269,7 @@ Header fields explained:
 1. Initial keying material (IKM):
    1. derive IKM from `secret` by hashing `secret` with SHA-256, or
    2. use 32 byte IKM when passed to library with `ikm`
-2. Generate 32 bytes of crypto random session id (`sid`) 
+2. Generate 32 bytes of crypto random session id (`sid`)
 3. Derive 32 byte encryption key and 12 byte initialization vector with HKDF using SHA-256 (on FIPS-mode it uses PBKDF2 with SHA-256 instead)
    1. Use HKDF extract to derive a new key from `ikm` to get `key` (this step can be done just once per `ikm`):
       - output length: `32`
@@ -1311,6 +1311,8 @@ The `PBKDF2` settings:
 
 Iteration counts are based on `remember_safety` setting (`"Low"`, `"Medium"`, `"High"`, `"Very High"`),
 if `remember_safety` is set to `"None"`, we will use the HDKF as above.
+
+*Note:* For backwards compatibility, we disabled the SP800-132 compliance checks on FIPS-mode. This checks that the salt length is at least 128 bits, the derived key length is at least 112 bits, and that the iteration count is at least 1000. These checks are disabled by default in OpenSSL's default provider, but are enabled by default in the FIPS provider.
 
 
 # Cookie Header Authentication

--- a/lib/resty/session/utils.lua
+++ b/lib/resty/session/utils.lua
@@ -592,11 +592,6 @@ local derive_pbkdf2_hmac_sha256 do
     PBKDF2_SHA256_OPTS.salt = usage .. ":" .. salt
     PBKDF2_SHA256_OPTS.pass = pass
 
-    -- Disables the SP800-132 compliance checks on FIPS-mode. This checks has constraints for the iteration count is at least 1000.
-    if is_fips_mode() then
-      PBKDF2_SHA256_OPTS.pkcs5 = 1
-    end
-
     key, err = pbkdf2:derive(size or 44, PBKDF2_SHA256_OPTS)
     if not key then
       pbkdf2 = nil
@@ -636,6 +631,7 @@ local derive_pbkdf2_hmac_sha256 do
         iter = 10000,
         salt = "",
         pass = "",
+        pkcs5 = 1, -- Disables the SP800-132 compliance checks on FIPS-mode
       }
     end
     derive_pbkdf2_hmac_sha256 = derive_pbkdf2_hmac_sha256_real

--- a/lib/resty/session/utils.lua
+++ b/lib/resty/session/utils.lua
@@ -592,6 +592,11 @@ local derive_pbkdf2_hmac_sha256 do
     PBKDF2_SHA256_OPTS.salt = usage .. ":" .. salt
     PBKDF2_SHA256_OPTS.pass = pass
 
+    -- Disables the SP800-132 compliance checks on FIPS-mode. This checks has constraints for the iteration count is at least 1000.
+    if is_fips_mode() then
+      PBKDF2_SHA256_OPTS.pkcs5 = 1
+    end
+
     key, err = pbkdf2:derive(size or 44, PBKDF2_SHA256_OPTS)
     if not key then
       pbkdf2 = nil


### PR DESCRIPTION
We use PBKDF2 with SHA-256 (single iteration) on FIPS-mode. However, the SP800-132 compliance checks have constraints, with an iteration count of at least 1000. If we do not disable this check, the following error will occur:

```
unable to derive session encryption key (kdf:derive: error:1C80007B:Provider routines:kdf_pbkdf2_set_ctx_params:invalid iteration count:implementations/kdfs/pbkdf2.c:208:)
```

For backwards compatibility, I would tend to disable the checks rather than increase the iteration.

Ref:

- https://github.com/openssl/openssl/blob/openssl-3.0.9/providers/implementations/kdfs/pbkdf2.c#L208
- https://github.com/openssl/openssl/commit/f0efeea29eca6e528a976f62ae2422eee34ea0eb