### PR TITLE
chore(*): release 4.1.4

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,11 @@
 
 All notable changes to `lua-resty-session` will be documented in this file.
 
+## [4.1.4] - 2025-08-11
+### Fixed
+- fix(redis-cluster): correctly pass username and password
+
+
 ## [4.1.3] - 2025-07-29
 ### Fixed
 - fix(utils): disable the SP800-132 compliance checks (on FIPS mode, but doesn't violate FIPS)

--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -2294,7 +2294,7 @@ end
 
 
 local session = {
-  _VERSION = "4.1.3",
+  _VERSION = "4.1.4",
   metatable = metatable,
 }
 

--- a/lib/resty/session/redis/cluster.lua
+++ b/lib/resty/session/redis/cluster.lua
@@ -207,12 +207,12 @@ function storage.new(configuration)
   local ssl_verify              = configuration and configuration.ssl_verify
   local server_name             = configuration and configuration.server_name
 
+
   local auth
-  if password then
-    if username then
-      auth = username .. " " .. password
-    else
+  if not username then
+    if password then
       auth = password
+      password = nil
     end
   end
 
@@ -234,6 +234,8 @@ function storage.new(configuration)
         max_connection_attempts = max_connection_attempts,
         max_connection_timeout = max_connection_timeout,
         auth = auth,
+        username = username,
+        password = password,
         connect_opts = {
           ssl = ssl,
           ssl_verify = ssl_verify,
@@ -263,6 +265,8 @@ function storage.new(configuration)
       max_connection_attempts = max_connection_attempts,
       max_connection_timeout = max_connection_timeout,
       auth = auth,
+      username = username,
+      password = password,
     },
   }, metatable)
 end

--- a/lua-resty-session-4.1.4-1.rockspec
+++ b/lua-resty-session-4.1.4-1.rockspec
@@ -1,8 +1,8 @@
 package = "lua-resty-session"
-version = "4.1.3-1"
+version = "4.1.4-1"
 source = {
   url = "git+https://github.com/bungle/lua-resty-session.git",
-  tag = "v4.1.3",
+  tag = "v4.1.4",
 }
 description = {
   summary = "Session Library for OpenResty - Flexible and Secure",


### PR DESCRIPTION
### Summary

- [fix(redis-cluster): correctly pass username and password](https://github.com/bungle/lua-resty-session/commit/0dc1417c1abdba9052dc19c805bf5e96af8e2731)